### PR TITLE
Correct failing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rn: react-native-community/react-native@1.1.0
+  rn: react-native-community/react-native@4.0.4
 
 jobs:
   checkout_code:


### PR DESCRIPTION
Bump react-native-circleci-orb to 3.0.1 to fix failing CI.