### PR TITLE
Add support a 'contain' resize mode for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If the cropping process is successful, the resultant cropped image will be store
 | `offset`      | Yes      | The top-left corner of the cropped image, specified in the original image's coordinate space                               |
 | `size`        | Yes      | Size (dimensions) of the cropped image                                                                                     |
 | `displaySize` | No       | Size to which you want to scale the cropped image                                                                          |
-| `resizeMode`  | No       | Resizing mode to use when scaling the image (iOS only, android resize mode is always 'cover') **Default value**: 'contain' |
+| `resizeMode`  | No       | Resizing mode to use when scaling the image ('stretch' resize mode is iOS only) **Default value**: 'contain' |
 
 ```javascript
   cropData = {

--- a/lib/ImageEditor.js
+++ b/lib/ImageEditor.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform} from 'react-native';
 
 const {RNCImageEditor} = NativeModules;
 
@@ -46,6 +46,51 @@ type ImageCropData = {
   }>,
 };
 
+type Size = {|
+  width: number,
+  height: number,
+|};
+
+type Params = {|
+  imageSize: Size,
+  rectSize: Size,
+|};
+
+export const containImageToRect = ({imageSize, rectSize}: Params): Size => {
+  const pageAspectRatio = rectSize.width / rectSize.height;
+  const imageAspectRatio = imageSize.width / imageSize.height;
+
+  if (imageAspectRatio >= pageAspectRatio) {
+    return {
+      width: rectSize.width,
+      height: rectSize.width / imageAspectRatio,
+    };
+  }
+
+  return {
+    width: rectSize.height * imageAspectRatio,
+    height: rectSize.height,
+  };
+};
+
+const processCropData = (cropData: ImageCropData): ImageCropData => {
+  if (
+    Platform.OS === 'android' &&
+    cropData.displaySize &&
+    (cropData.resizeMode === 'contain' || cropData.resizeMode === undefined)
+  ) {
+    return {
+      ...cropData,
+      displaySize: containImageToRect({
+        imageSize: cropData.size,
+        rectSize: cropData.displaySize,
+      }),
+    };
+  }
+
+  return cropData;
+};
+
 class ImageEditor {
   /**
    * Crop the image specified by the URI param. If URI points to a remote
@@ -60,7 +105,7 @@ class ImageEditor {
    * cropped image from the cache path when you are done with it.
    */
   static cropImage(uri: string, cropData: ImageCropData): Promise<string> {
-    return RNCImageEditor.cropImage(uri, cropData);
+    return RNCImageEditor.cropImage(uri, processCropData(cropData));
   }
 }
 


### PR DESCRIPTION

This PR adds breaking changes!

## Test Plan

![demo gif](https://media.giphy.com/media/yTmWU4IQvAQN4VY4G1/giphy.gif)


1) Install:
```sh
npx react-native init testEditor
cd testEditor
yarn add retyui/react-native-image-editor#android-contain-resize-mode
```
2) Paste code from [example/App.js](https://github.com/react-native-community/react-native-image-editor/blob/master/example/src/App.js)

3) Extends crop data

```diff
const cropData: ImageCropData = {
  offset: {
    x: this.props.image.width * offsetRatioX,
    y: this.props.image.height * offsetRatioY,
  },
  size: {
    width: this.props.image.width * sizeRatioX,
    height: this.props.image.height * sizeRatioY,
  },
+  resizeMode: 'contain',
+  displaySize: {
+    width: 2000,
+    height: 1000,
+  },
};
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
