### PR TITLE
fix: use of external storage should be optional

### DIFF
--- a/lib/ImageEditor.js
+++ b/lib/ImageEditor.js
@@ -44,6 +44,11 @@ type ImageCropData = {
     cover: string,
     stretch: string,
   }>,
+
+  /**
+   * (Optional) if true, will disable the use of external cache.
+   * */
+  useInternalCache?: boolean,
 };
 
 class ImageEditor {
@@ -59,7 +64,10 @@ class ImageEditor {
    * will point to the image in the cache path. Remember to delete the
    * cropped image from the cache path when you are done with it.
    */
-  static cropImage(uri: string, cropData: ImageCropData): Promise<string> {
+  static cropImage(
+    uri: string,
+    cropData: ImageCropData
+  ): Promise<string> {
     return RNCImageEditor.cropImage(uri, cropData);
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,11 @@ export type ImageCropData = {
    * `displaySize` param is not specified, this has no effect.
    */
   resizeMode?: $Maybe<"contain" | "cover" | "stretch">,
+
+  /**
+   * (Optional) if true, will disable the use of external cache.
+   **/
+  useInternalCache?: boolean,
 };
 
 declare class ImageEditor {
@@ -46,7 +51,7 @@ declare class ImageEditor {
    */
   static cropImage: (
     uri: string,
-    cropData: ImageCropData,
+    cropData: ImageCropData
   ) => Promise<string>
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This adds an option to make the use of external cache optional.

### Test plan

Call `cropImage` and pass in `useInternalCache` as `true` to the crop options; and it will force it to only use the internal cache.
