### PR TITLE
Update "react-native" peerDependencies to allow usage with latest RN versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "react": ">=16.0",
-    "react-native": ">=0.57 <0.65"
+    "react-native": ">=0.57"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
### Summary

If this is working with 0.64, there is no reason it shouldn't work with 0.65-0.68 afaik.
This prevent "npm yelling" if you want to install it.

### Test plan

`npm install` with recent npm version (> 8.5 probably) which breaks install if peer deps are not respected.
