### PR TITLE
fix: incompatibility with AGP 8 & remove jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -18,11 +18,31 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['RNImageEditor_' + name]).toInteger()
 }
 
+def supportsNamespace() {
+  def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+  def major = parsed[0].toInteger()
+  def minor = parsed[1].toInteger()
+
+  // Namespace support was added in 7.3.0
+  return (major == 7 && minor >= 3) || major >= 8
+}
+
+
 apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
     buildToolsVersion getExtOrDefault('buildToolsVersion')
+
+    if (supportsNamespace()) {
+        namespace "com.reactnativecommunity.imageeditor"
+
+        sourceSets {
+            main {
+                manifest.srcFile "src/main/AndroidManifestNew.xml"
+            }
+        }
+    }
 
     defaultConfig {
         minSdkVersion getExtOrIntegerDefault('minSdkVersion')

--- a/android/src/main/AndroidManifestNew.xml
+++ b/android/src/main/AndroidManifestNew.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

fix: incompatibility with AGP 8 & remove jcenter

- add missing namespace field in `build.gradle` to make it compatible with Android Gradle Plugin 8 (https://github.com/react-native-community/discussions-and-proposals/issues/671)
- replace jcenter with mavencentral

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Create test 0.73 RN app, install the library and run the app
