### PR TITLE
Fix npm install for versions 7 and higher.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,12 @@
     "test:detox:clean": "rimraf example/android/build && rimraf example/android/app/build && rimraf example/android/.gradle && rimraf example/ios/build"
   },
   "peerDependencies": {
-    "react": ">=16.0",
-    "react-native": ">=0.57 <0.65"
+    "react-native": ">=0.57"
+  },
+  "peerDependenciesMeta": {
+    "react-native": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
### Summary

1. this library is never used `react`
2. npm 7 and above will block installations if an upstream dependency conflict is present that cannot be automatically resolved.

fix: 
- https://github.com/callstack/react-native-image-editor/issues/114
- https://github.com/callstack/react-native-image-editor/issues/105
- https://github.com/callstack/react-native-image-editor/issues/101
- https://github.com/callstack/react-native-image-editor/issues/93
- https://github.com/callstack/react-native-image-editor/issues/79
- https://github.com/callstack/react-native-image-editor/issues/70
- https://github.com/callstack/react-native-image-editor/issues/60


### Test plan

```tsx
npm -v # 7 or above
npx react-native init tmpRN71 --version 0.71.x --npm
cd tmpRN71
npm install /path/to/image-editor
```
