### PR TITLE
feature: Add compression quality prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ ImageEditor.cropImage(uri, cropData).then(url => {
 | `size`        | Yes      | Size (dimensions) of the cropped image                                                                                     |
 | `displaySize` | No       | Size to which you want to scale the cropped image                                                                          |
 | `resizeMode`  | No       | Resizing mode to use when scaling the image (iOS only, android resize mode is always 'cover') **Default value**: 'contain' |
+| `quality`     | No       | The quality of the resulting image, expressed as a value from `0.0` to `1.0`. <br/>The value `0.0` represents the maximum compression (or lowest quality) while the value `1.0` represents the least compression (or best quality).<br/>iOS supports only `JPEG` format, while Android supports both `JPEG`, `WEBP` and `PNG` formats.<br/>**Default value**:  (iOS: `1`), (Android: `0.9`) |
 
 ```ts
 cropData: ImageCropData = {
@@ -56,6 +57,7 @@ cropData: ImageCropData = {
   size: {width: number, height: number},
   displaySize: {width: number, height: number},
   resizeMode: 'contain' | 'cover' | 'stretch',
+  quality: number // 0...1
 };
 ```
 

--- a/src/NativeRNCImageEditor.ts
+++ b/src/NativeRNCImageEditor.ts
@@ -1,5 +1,5 @@
 import type { TurboModule } from 'react-native';
-import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
+import type { Double, Float } from 'react-native/Libraries/Types/CodegenTypes';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
@@ -35,6 +35,11 @@ export interface Spec extends TurboModule {
        * `displaySize` param is not specified, this has no effect.
        */
       resizeMode?: string;
+
+      /**
+       * (Optional) Compression quality jpg images (number from 0 to 1).
+       */
+      quality?: Float;
     }
   ): Promise<string>;
 }


### PR DESCRIPTION
### Summary

Allow to change quality of the resulting image via passing `quality: number` prop. Used the default values without making any breaking changes.

### Test plan

Example:

https://github.com/callstack/react-native-image-editor/assets/4661784/81212d46-6e45-4f1c-bd18-fffa5fbf341d


