### PR TITLE
feature: [web/android/ios] Upon success, return more image information

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,21 @@ Crop the image specified by the URI param. If URI points to a remote image, it w
 If the cropping process is successful, the resultant cropped image will be stored in the cache path, and the URI returned in the promise will point to the image in the cache path. Remember to delete the cropped image from the cache path when you are done with it.
 
 ```ts
-ImageEditor.cropImage(uri, cropData).then((url) => {
-  console.log('Cropped image uri', url);
-  // In case of Web, the `url` is the base64 string
-});
+ImageEditor.cropImage(uri, cropData).then(
+  ({
+    uri, // the path to the image file (example: 'file:///data/user/0/.../image.jpg')
+    path, // the URI of the image (example: '/data/user/0/.../image.jpg')
+    name, // the name of the image file. (example: 'image.jpg')
+    width, // the width of the image in pixels
+    height, // height of the image in pixels
+    size, // the size of the image in bytes
+  }) => {
+    console.log('Cropped image uri:', uri);
+    // WEB has different response:
+    // - `uri`  is the base64 string (example `data:image/jpeg;base64,/4AAQ...AQABAA`)
+    // - `path` is the blob URL      (example `blob:https://example.com/43ff7a16...e46b1`)
+  }
+);
 ```
 
 ### `cropData: ImageCropData`

--- a/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModuleImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/imageeditor/ImageEditorModuleImpl.kt
@@ -23,10 +23,12 @@ import android.util.Base64 as AndroidUtilBase64
 import androidx.exifinterface.media.ExifInterface
 import com.facebook.common.logging.FLog
 import com.facebook.infer.annotation.Assertions
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.ReactConstants
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -162,7 +164,7 @@ class ImageEditorModuleImpl(private val reactContext: ReactApplicationContext) {
                 if (mimeType == MimeType.JPEG) {
                     copyExif(reactContext, Uri.parse(uri), tempFile)
                 }
-                promise.resolve(Uri.fromFile(tempFile).toString())
+                promise.resolve(getResultMap(tempFile, cropped))
             } catch (e: Exception) {
                 promise.reject(e)
             }
@@ -437,6 +439,17 @@ class ImageEditorModuleImpl(private val reactContext: ReactApplicationContext) {
             )
 
         // Utils
+        private fun getResultMap(resizedImage: File, image: Bitmap): WritableMap {
+            val response = Arguments.createMap()
+            response.putString("path", resizedImage.absolutePath)
+            response.putString("uri", Uri.fromFile(resizedImage).toString())
+            response.putString("name", resizedImage.name)
+            response.putInt("size", resizedImage.length().toInt())
+            response.putInt("width", image.width)
+            response.putInt("height", image.height)
+            return response
+        }
+
         private fun getMimeType(outOptions: BitmapFactory.Options, format: String?): String {
             val mimeType =
                 when (format) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -807,7 +807,7 @@ PODS:
   - React-jsinspector (0.72.6)
   - React-logger (0.72.6):
     - glog
-  - react-native-image-editor (3.1.0):
+  - react-native-image-editor (3.2.0):
     - RCT-Folly (= 2021.07.22.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1129,7 +1129,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: faca9c368233f59ed24601aca0185870466a96e9
   React-jsinspector: 194e32c6aab382d88713ad3dd0025c5f5c4ee072
   React-logger: cebf22b6cf43434e471dc561e5911b40ac01d289
-  react-native-image-editor: a58ef0223f36bd9b8aa5c2b9d45926ce51946e50
+  react-native-image-editor: ed27495b9a98482d6f4642c42b165dfe23523b8d
   React-NativeModulesApple: 63505fb94b71e2469cab35bdaf36cca813cb5bfd
   React-perflogger: e3596db7e753f51766bceadc061936ef1472edc3
   React-RCTActionSheet: 17ab132c748b4471012abbcdcf5befe860660485

--- a/example/src/SquareImageCropper.tsx
+++ b/example/src/SquareImageCropper.tsx
@@ -131,12 +131,12 @@ export class SquareImageCropper extends Component<Props, State> {
       if (!this._transformData) {
         return;
       }
-      const croppedImageURI = await ImageEditor.cropImage(
+      const { uri } = await ImageEditor.cropImage(
         this.state.photo.uri,
         this._transformData
       );
-      if (croppedImageURI) {
-        this.setState({ croppedImageURI });
+      if (uri) {
+        this.setState({ croppedImageURI: uri });
       }
     } catch (cropError) {
       if (cropError instanceof Error) {

--- a/ios/RNCImageEditor.mm
+++ b/ios/RNCImageEditor.mm
@@ -122,7 +122,6 @@ RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
       path = [RNCFileSystem generatePathInDirectory:[[RNCFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"ReactNative_cropped_image_"] withExtension:@".png"];
     }
     else{
-
       imageData = UIImageJPEGRepresentation(croppedImage, compressionQuality);
       path = [RNCFileSystem generatePathInDirectory:[[RNCFileSystem cacheDirectoryPath] stringByAppendingPathComponent:@"ReactNative_cropped_image_"] withExtension:@".jpg"];
     }
@@ -135,7 +134,21 @@ RCT_EXPORT_METHOD(cropImage:(NSURLRequest *)imageRequest
       return;
     }
 
-    resolve(uri);
+    NSURL *fileurl = [[NSURL alloc] initFileURLWithPath:path];
+    NSString *filename = fileurl.lastPathComponent;
+    NSError *attributesError = nil;
+    NSDictionary *fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:&attributesError];
+    NSNumber *fileSize = fileAttributes == nil ? 0 : [fileAttributes objectForKey:NSFileSize];
+    NSDictionary *response = @{
+       @"path": path,
+       @"uri": uri,
+       @"name": filename,
+       @"size": fileSize ?: @(0),
+       @"width": @(croppedImage.size.width),
+       @"height": @(croppedImage.size.height),
+    };
+
+    resolve(response);
   }];
 }
 

--- a/src/NativeRNCImageEditor.ts
+++ b/src/NativeRNCImageEditor.ts
@@ -1,5 +1,9 @@
 import type { TurboModule } from 'react-native';
-import type { Double, Float } from 'react-native/Libraries/Types/CodegenTypes';
+import type {
+  Double,
+  Float,
+  Int32,
+} from 'react-native/Libraries/Types/CodegenTypes';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
@@ -46,7 +50,32 @@ export interface Spec extends TurboModule {
        */
       format?: string;
     }
-  ): Promise<string>;
+  ): Promise<{
+    /**
+     *  The path to the image file (example: '/data/user/0/.../image.jpg')
+     */
+    path: string;
+    /**
+     * The URI of the image (example: 'file:///data/user/0/.../image.jpg')
+     */
+    uri: string;
+    /**
+     * The name of the image file. (example: 'image.jpg')
+     */
+    name: string;
+    /**
+     * The width of the image in pixels
+     */
+    width: Int32;
+    /**
+     * The height of the image in pixels
+     */
+    height: Int32;
+    /**
+     * The size of the image in bytes
+     */
+    size: Int32;
+  }>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNCImageEditor');

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
 import { Platform } from 'react-native';
 import NativeRNCImageEditor from './NativeRNCImageEditor';
 import type { Spec } from './NativeRNCImageEditor';
-import type { ImageCropData } from './types.ts';
+import type { ImageCropData, CropResult } from './types.ts';
 
 const LINKING_ERROR =
   `The package '@react-native-community/image-editor' doesn't seem to be linked. Make sure: \n\n` +
@@ -37,7 +37,7 @@ class ImageEditor {
    * will point to the image in the cache path. Remember to delete the
    * cropped image from the cache path when you are done with it.
    */
-  static cropImage(uri: string, cropData: ImageCropData): Promise<string> {
+  static cropImage(uri: string, cropData: ImageCropData): CropResult {
     return RNCImageEditor.cropImage(uri, cropData);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,5 @@ export interface ImageCropData
   // ^^^ codegen doesn't support union types yet
   // so to provide more type safety we override the type here
 }
+
+export type CropResult = ReturnType<Spec['cropImage']>;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Part of `4.x` release: Convert a `uri` crop result to an `object`


### Test plan

Examples: 

```json
// web
{
    "width": 1125,
    "height": 750,
    "name": "ReactNative_cropped_image.jpeg",
    "size": 283213,
    "path": "blob:http://localhost:8082/43ff7a16-c464-4130-a3d2-95286bae46b1",
    "uri": "data:image/jpeg;base64,/9j/4A|"
}
// android
{
  "height": 600,
  "size": 31520,
  "name": "ReactNative_cropped_image_5129169684629022727.jpg",
  "width": 800,
  "uri": "file:///data/user/0/com.rn73/cache/ReactNative_cropped_image_5129169684629022727.jpg",
  "path": "/data/user/0/com.rn73/cache/ReactNative_cropped_image_5129169684629022727.jpg"
}
// ios
{
  "path": "/Users/davydnarbutovich/Library/Developer/CoreSimulator/Devices/0CA37DFB-8AF0-4714-A849-82E2EE03634F/data/Containers/Data/Application/AD103DB7-10DA-4D4E-A7DD-BDCE371A961D/Library/Caches/ReactNative_cropped_image_/431C35F1-29EC-4972-84C5-01574DDCFDEE.png",
  "size": 280504,
  "height": 800,
  "name": "431C35F1-29EC-4972-84C5-01574DDCFDEE.png",
  "uri": "file:///Users/davydnarbutovich/Library/Developer/CoreSimulator/Devices/0CA37DFB-8AF0-4714-A849-82E2EE03634F/data/Containers/Data/Application/AD103DB7-10DA-4D4E-A7DD-BDCE371A961D/Library/Caches/ReactNative_cropped_image_/431C35F1-29EC-4972-84C5-01574DDCFDEE.png",
  "width": 600
}
```