### PR TITLE
feature: Add base64 output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,47 +36,38 @@ import ImageEditor from '@react-native-community/image-editor';
 
 Crop the image specified by the URI param. If URI points to a remote image, it will be downloaded automatically. If the image cannot be loaded/downloaded, the promise will be rejected.
 
-If the cropping process is successful, the resultant cropped image will be stored in the cache path, and the URI returned in the promise will point to the image in the cache path. Remember to delete the cropped image from the cache path when you are done with it.
+If the cropping process is successful, the resultant cropped image will be stored in the cache path, and the [`CropResult`](#result-cropresult) returned in the promise will point to the image in the cache path. ⚠️ Remember to delete the cropped image from the cache path when you are done with it.
 
 ```ts
-ImageEditor.cropImage(uri, cropData).then(
-  ({
-    uri, // the path to the image file (example: 'file:///data/user/0/.../image.jpg')
-    path, // the URI of the image (example: '/data/user/0/.../image.jpg')
-    name, // the name of the image file. (example: 'image.jpg')
-    width, // the width of the image in pixels
-    height, // height of the image in pixels
-    size, // the size of the image in bytes
-  }) => {
-    console.log('Cropped image uri:', uri);
-    // WEB has different response:
-    // - `uri`  is the base64 string (example `data:image/jpeg;base64,/4AAQ...AQABAA`)
-    // - `path` is the blob URL      (example `blob:https://example.com/43ff7a16...e46b1`)
-  }
-);
+ImageEditor.cropImage(uri, cropData).then((result) => {
+  console.log('Cropped image uri:', result.uri);
+});
 ```
 
 ### `cropData: ImageCropData`
 
-| Property      | Required | Description                                                                                                                                                                                                                                                                                                                                                             |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `offset`      | Yes      | The top-left corner of the cropped image, specified in the original image's coordinate space                                                                                                                                                                                                                                                                            |
-| `size`        | Yes      | Size (dimensions) of the cropped image                                                                                                                                                                                                                                                                                                                                  |
-| `displaySize` | No       | Size to which you want to scale the cropped image                                                                                                                                                                                                                                                                                                                       |
-| `resizeMode`  | No       | Resizing mode to use when scaling the image (iOS only, Android resize mode is always `'cover'`, Web - no support) **Default value**: `'cover'`                                                                                                                                                                                                                          |
-| `quality`     | No       | The quality of the resulting image, expressed as a value from `0.0` to `1.0`. <br/>The value `0.0` represents the maximum compression (or lowest quality) while the value `1.0` represents the least compression (or best quality).<br/>iOS supports only `JPEG` format, while Android/Web supports both `JPEG`, `WEBP` and `PNG` formats.<br/>**Default value**: `0.9` |
-| `format`      | No       | The format of the resulting image, possible values are `jpeg`, `png`, `webp`. <br/> **Default value**: based on the provided image; if value determination is not possible, `jpeg` will be used as a fallback. <br/> `webp` isn't supported by iOS.                                                                                                                     |
+| Name                            | Type                                            | Description                                                                                                                                                                                                  |
+| ------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `offset`                        | `{ x: number, y: number }`                      | The top-left corner of the cropped image, specified in the original image's coordinate space                                                                                                                 |
+| `size`                          | `{ width: number, height: number }`             | Size (dimensions) of the cropped image                                                                                                                                                                       |
+| `displaySize`<br>_(optional)_   | `{ width: number, height: number }`             | Size to which you want to scale the cropped image                                                                                                                                                            |
+| `resizeMode`<br>_(optional)_    | `'contain' \| 'cover' \| 'stretch' \| 'center'` | Resizing mode to use when scaling the image (iOS only, Android resize mode is always `'cover'`, Web - no support) <br/>**Default value**: `'cover'`                                                          |
+| `quality`<br>_(optional)_       | `number`                                        | A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality) <br/>**Default value**: `0.9`   |
+| `format`<br>_(optional)_        | `'jpeg' \| 'png' \| 'webp'`                     | The format of the resulting image.<br/> **Default value**: based on the provided image;<br>if value determination is not possible, `'jpeg'` will be used as a fallback.<br/>`'webp'` isn't supported by iOS. |
+| `includeBase64`<br>_(optional)_ | `boolean`                                       | Indicates if Base64 formatted picture data should also be included in the [`CropResult`](#result-cropresult). <br/>**Default value**: `false`                                                                |
 
-```ts
-cropData: ImageCropData = {
-  offset: { x: number, y: number },
-  size: { width: number, height: number },
-  displaySize: { width: number, height: number },
-  resizeMode: 'contain' | 'cover' | 'stretch',
-  quality: number, // 0...1
-  format: 'jpeg' | 'png' | 'webp',
-};
-```
+### `result: CropResult`
+
+| Name                     | Type     | Description                                                                                                                                                                                    |
+| ------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uri`                    | `string` | The path to the image file (example: `'file:///data/user/0/.../image.jpg'`)<br> **WEB:** `uri` is the data URI string (example `'data:image/jpeg;base64,/4AAQ...AQABAA'`)                      |
+| `path`                   | `string` | The URI of the image (example: `'/data/user/0/.../image.jpg'`)<br> **WEB:** `path` is the blob URL (example `'blob:https://example.com/43ff7a16...e46b1'`)                                     |
+| `name`                   | `string` | The name of the image file. (example: `'image.jpg'`)                                                                                                                                           |
+| `width`                  | `number` | The width of the image in pixels                                                                                                                                                               |
+| `height`                 | `number` | Height of the image in pixels                                                                                                                                                                  |
+| `size`                   | `number` | The size of the image in bytes                                                                                                                                                                 |
+| `type`                   | `string` | The MIME type of the image (`'image/jpeg'`, `'image/png'`, `'image/webp'`)                                                                                                                     |
+| `base64`<br>_(optional)_ | `string` | The base64-encoded image data example: `'/9j/4AAQSkZJRgABAQAAAQABAAD'`<br>if you need data URI as the `source` for an `Image` element for example, you can use `data:${type};base64,${base64}` |
 
 For more advanced usage check our [example app](/example/src/App.tsx).
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "!android/gradlew",
     "!android/gradlew.bat",
     "!android/local.properties",
+    "!**/__typetests__",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",

--- a/src/NativeRNCImageEditor.ts
+++ b/src/NativeRNCImageEditor.ts
@@ -49,6 +49,11 @@ export interface Spec extends TurboModule {
        * (Optional) The format of the resulting image. Default auto-detection based on given image
        */
       format?: string;
+
+      /**
+       * (Optional) Indicates if Base64 formatted picture data should also be included in the result.
+       */
+      includeBase64?: boolean;
     }
   ): Promise<{
     /**
@@ -75,6 +80,16 @@ export interface Spec extends TurboModule {
      * The size of the image in bytes
      */
     size: Int32;
+
+    /**
+     * MIME type of the image (example: 'image/jpeg')
+     */
+    type: string;
+
+    /**
+     * The base64 string of the image if the `base64` param is true
+     */
+    base64?: string;
   }>;
 }
 

--- a/src/__typetests__/index.ts
+++ b/src/__typetests__/index.ts
@@ -1,0 +1,35 @@
+/* eslint-disable */
+import ImageEditorNative from '../index.ts';
+
+const requiredParams = {
+  size: { width: 100, height: 100 },
+  offset: { x: 0, y: 0 },
+};
+
+ImageEditorNative.cropImage('<test>', {
+  ...requiredParams,
+  includeBase64: true,
+  // ^^^: if `true` then result has `base64` property as string
+}).then((e) => {
+  const a: string = e.base64;
+  // @ts-expect-error - base64 is a string
+  const b: number = e.base64;
+});
+
+ImageEditorNative.cropImage('<test>', {
+  ...requiredParams,
+  includeBase64: false,
+  // ^^^: if `false` then result doesn't have `base64` property
+}).then((e) => {
+  // @ts-expect-error - base64 doesn't exist
+  const a: string = e.base64;
+});
+
+ImageEditorNative.cropImage('<test>', {
+  ...requiredParams,
+  // includeBase64: false,
+  // ^^^: if `undefined` then result doesn't have `base64` property
+}).then((e) => {
+  // @ts-expect-error - base64 doesn't exist
+  const a: string = e.base64;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,9 @@ const RNCImageEditor: Spec = NativeRNCImageEditor
       },
     });
 
+type CropResultWithoutBase64 = Omit<CropResult, 'base64'>;
+type ImageCropDataWithoutBase64 = Omit<ImageCropData, 'includeBase64'>;
+
 class ImageEditor {
   /**
    * Crop the image specified by the URI param. If URI points to a remote
@@ -37,8 +40,23 @@ class ImageEditor {
    * will point to the image in the cache path. Remember to delete the
    * cropped image from the cache path when you are done with it.
    */
-  static cropImage(uri: string, cropData: ImageCropData): CropResult {
-    return RNCImageEditor.cropImage(uri, cropData);
+
+  // TS overload for better `base64` type inference (see: `src/__typetests__/index.ts`)
+  static cropImage(
+    uri: string,
+    cropData: ImageCropDataWithoutBase64
+  ): Promise<CropResultWithoutBase64>;
+  static cropImage(
+    uri: string,
+    cropData: ImageCropDataWithoutBase64 & { includeBase64: false }
+  ): Promise<CropResultWithoutBase64>;
+  static cropImage(
+    uri: string,
+    cropData: ImageCropDataWithoutBase64 & { includeBase64: true }
+  ): Promise<CropResultWithoutBase64 & { base64: string }>;
+
+  static cropImage(uri: string, cropData: ImageCropData): Promise<CropResult> {
+    return RNCImageEditor.cropImage(uri, cropData) as Promise<CropResult>;
   }
 }
 

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -51,7 +51,10 @@ function fetchImage(imgSrc: string): Promise<HTMLImageElement> {
 const DEFAULT_COMPRESSION_QUALITY = 0.9;
 
 class ImageEditor {
-  static cropImage(imgSrc: string, cropData: ImageCropData): CropResult {
+  static cropImage(
+    imgSrc: string,
+    cropData: ImageCropData
+  ): Promise<CropResult> {
     /**
      * Returns a promise that resolves with the base64 encoded string of the cropped image
      */
@@ -72,10 +75,11 @@ class ImageEditor {
 
         let _path: string, _uri: string;
 
-        return {
+        const result: CropResult = {
           width: canvas.width,
           height: canvas.height,
           name: 'ReactNative_cropped_image.' + ext,
+          type: ('image/' + ext) as CropResult['type'],
           size: blob.size,
           // Lazy getters to avoid unnecessary memory usage
           get path() {
@@ -85,12 +89,18 @@ class ImageEditor {
             return _path;
           },
           get uri() {
+            return result.base64 as string;
+          },
+          get base64() {
             if (!_uri) {
               _uri = canvas.toDataURL(type, quality);
             }
-            return _uri;
+            return _uri.split(',')[1];
+            // ^^^ remove `data:image/xxx;base64,` prefix (to align with iOS/Android platform behavior)
           },
         };
+
+        return result;
       });
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,4 +10,13 @@ export interface ImageCropData
   // so to provide more type safety we override the type here
 }
 
-export type CropResult = ReturnType<Spec['cropImage']>;
+export interface CropResult
+  extends Omit<AsyncReturnType<Spec['cropImage']>, 'type'> {
+  type: 'image/jpeg' | 'image/png' | 'image/webp';
+  // ^^^ codegen doesn't support union types yet
+}
+
+// Utils
+type AsyncReturnType<T> = T extends (...args: any[]) => Promise<infer R>
+  ? R
+  : never;


### PR DESCRIPTION
### Summary

Changes
- Update [README.md](https://github.com/callstack/react-native-image-editor/blob/ce8f6523c2fb8a3b24df2638afa70b9c1eca5072/README.md#react-native-image-editor)
- Add `base64` output support
- Add a new result prop `type: 'image/jpeg' | 'image/webp' | 'image/png'`
- Add Typescript tests


### Test plan

...
