### PR TITLE
Allow pass `headers`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ ImageEditor.cropImage(uri, cropData).then((result) => {
 | `quality`<br>_(optional)_       | `number`                                        | A value in range `0.0` - `1.0` specifying compression level of the result image. `1` means no compression (highest quality) and `0` the highest compression (lowest quality) <br/>**Default value**: `0.9`   |
 | `format`<br>_(optional)_        | `'jpeg' \| 'png' \| 'webp'`                     | The format of the resulting image.<br/> **Default value**: based on the provided image;<br>if value determination is not possible, `'jpeg'` will be used as a fallback.<br/>`'webp'` isn't supported by iOS. |
 | `includeBase64`<br>_(optional)_ | `boolean`                                       | Indicates if Base64 formatted picture data should also be included in the [`CropResult`](#result-cropresult). <br/>**Default value**: `false`                                                                |
+| `headers`<br>_(optional)_       | `object \| Headers`                             | An object or [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) interface representing the HTTP headers to send along with the request for a remote image.                                |
 
 ### `result: CropResult`
 

--- a/src/NativeRNCImageEditor.ts
+++ b/src/NativeRNCImageEditor.ts
@@ -54,6 +54,13 @@ export interface Spec extends TurboModule {
        * (Optional) Indicates if Base64 formatted picture data should also be included in the result.
        */
       includeBase64?: boolean;
+
+      /**
+       * (Optional) An object representing the HTTP headers to send along with the request for a remote image.
+       */
+      headers?: {
+        [key: string]: string;
+      };
     }
   ): Promise<{
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,17 @@ const RNCImageEditor: Spec = NativeRNCImageEditor
 type CropResultWithoutBase64 = Omit<CropResult, 'base64'>;
 type ImageCropDataWithoutBase64 = Omit<ImageCropData, 'includeBase64'>;
 
+function toHeadersObject(
+  headers: ImageCropData['headers']
+): Record<string, string> | undefined {
+  return headers instanceof Headers
+    ? Object.fromEntries(
+        // @ts-expect-error: Headers.entries isn't added yet in TS but exists in Runtime
+        headers.entries()
+      )
+    : headers;
+}
+
 class ImageEditor {
   /**
    * Crop the image specified by the URI param. If URI points to a remote
@@ -56,7 +67,10 @@ class ImageEditor {
   ): Promise<CropResultWithoutBase64 & { base64: string }>;
 
   static cropImage(uri: string, cropData: ImageCropData): Promise<CropResult> {
-    return RNCImageEditor.cropImage(uri, cropData) as Promise<CropResult>;
+    return RNCImageEditor.cropImage(uri, {
+      ...cropData,
+      headers: toHeadersObject(cropData.headers),
+    }) as Promise<CropResult>;
   }
 }
 

--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -1,14 +1,16 @@
 import type { ImageCropData, CropResult } from './types.ts';
 
+const ERROR_PREFIX = 'ImageEditor: ';
+
 function drawImage(
-  img: HTMLImageElement,
+  img: HTMLImageElement | ImageBitmap,
   { offset, size, displaySize }: ImageCropData
 ): HTMLCanvasElement {
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d');
 
   if (!context) {
-    throw new Error('Failed to get canvas context');
+    throw new Error(ERROR_PREFIX + 'Failed to get canvas context');
   }
 
   const sx = offset.x,
@@ -28,7 +30,30 @@ function drawImage(
   return canvas;
 }
 
-function fetchImage(imgSrc: string): Promise<HTMLImageElement> {
+function fetchImage(
+  imgSrc: string,
+  headers: ImageCropData['headers']
+): Promise<HTMLImageElement | ImageBitmap> {
+  if (headers) {
+    return fetch(imgSrc, {
+      method: 'GET',
+      headers: new Headers(headers),
+    })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            ERROR_PREFIX +
+              'Failed to fetch the image: ' +
+              imgSrc +
+              '. Request failed with status: ' +
+              response.status
+          );
+        }
+        return response.blob();
+      })
+      .then((blob) => createImageBitmap(blob));
+  }
+
   return new Promise<HTMLImageElement>((resolve, reject) => {
     const onceOptions = { once: true };
     const img = new Image();
@@ -58,51 +83,53 @@ class ImageEditor {
     /**
      * Returns a promise that resolves with the base64 encoded string of the cropped image
      */
-    return fetchImage(imgSrc).then(function onfulfilledImgToCanvas(image) {
-      const ext = cropData.format ?? 'jpeg';
-      const type = `image/${ext}`;
-      const quality = cropData.quality ?? DEFAULT_COMPRESSION_QUALITY;
-      const canvas = drawImage(image, cropData);
+    return fetchImage(imgSrc, cropData.headers).then(
+      function onfulfilledImgToCanvas(image) {
+        const ext = cropData.format ?? 'jpeg';
+        const type = `image/${ext}`;
+        const quality = cropData.quality ?? DEFAULT_COMPRESSION_QUALITY;
+        const canvas = drawImage(image, cropData);
 
-      return new Promise<Blob | null>(function onfulfilledCanvasToBlob(
-        resolve
-      ) {
-        canvas.toBlob(resolve, type, quality);
-      }).then((blob) => {
-        if (!blob) {
-          throw new Error('Image cannot be created from canvas');
-        }
+        return new Promise<Blob | null>(function onfulfilledCanvasToBlob(
+          resolve
+        ) {
+          canvas.toBlob(resolve, type, quality);
+        }).then((blob) => {
+          if (!blob) {
+            throw new Error('Image cannot be created from canvas');
+          }
 
-        let _path: string, _uri: string;
+          let _path: string, _uri: string;
 
-        const result: CropResult = {
-          width: canvas.width,
-          height: canvas.height,
-          name: 'ReactNative_cropped_image.' + ext,
-          type: ('image/' + ext) as CropResult['type'],
-          size: blob.size,
-          // Lazy getters to avoid unnecessary memory usage
-          get path() {
-            if (!_path) {
-              _path = URL.createObjectURL(blob);
-            }
-            return _path;
-          },
-          get uri() {
-            return result.base64 as string;
-          },
-          get base64() {
-            if (!_uri) {
-              _uri = canvas.toDataURL(type, quality);
-            }
-            return _uri.split(',')[1];
-            // ^^^ remove `data:image/xxx;base64,` prefix (to align with iOS/Android platform behavior)
-          },
-        };
+          const result: CropResult = {
+            width: canvas.width,
+            height: canvas.height,
+            name: 'ReactNative_cropped_image.' + ext,
+            type: ('image/' + ext) as CropResult['type'],
+            size: blob.size,
+            // Lazy getters to avoid unnecessary memory usage
+            get path() {
+              if (!_path) {
+                _path = URL.createObjectURL(blob);
+              }
+              return _path;
+            },
+            get uri() {
+              return result.base64 as string;
+            },
+            get base64() {
+              if (!_uri) {
+                _uri = canvas.toDataURL(type, quality);
+              }
+              return _uri.split(',')[1];
+              // ^^^ remove `data:image/xxx;base64,` prefix (to align with iOS/Android platform behavior)
+            },
+          };
 
-        return result;
-      });
-    });
+          return result;
+        });
+      }
+    );
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,8 @@ import type { Spec } from './NativeRNCImageEditor.ts';
 type ImageCropDataFromSpec = Parameters<Spec['cropImage']>[1];
 
 export interface ImageCropData
-  extends Omit<ImageCropDataFromSpec, 'resizeMode' | 'format'> {
+  extends Omit<ImageCropDataFromSpec, 'headers' | 'resizeMode' | 'format'> {
+  headers?: Record<string, string> | Headers;
   format?: 'png' | 'jpeg' | 'webp';
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center';
   // ^^^ codegen doesn't support union types yet


### PR DESCRIPTION
### Summary

Fix: https://github.com/callstack/react-native-image-editor/issues/66

### Test plan

**Data**

```js
headers: {
      'x-string': 'my string',
},
```

**Android**

<img width="831" alt="Screenshot 2024-03-01 at 00 06 24" src="https://github.com/callstack/react-native-image-editor/assets/4661784/1367b473-6181-416f-aae7-95be3c2e6be4">


**iOS**

<img width="657" alt="Screenshot 2024-02-29 at 23 41 41" src="https://github.com/callstack/react-native-image-editor/assets/4661784/44e6ff7b-83e5-4544-a399-dfcac1a58bb9">


**Web**

<img width="754" alt="Screenshot 2024-03-01 at 00 49 03" src="https://github.com/callstack/react-native-image-editor/assets/4661784/a83a0106-f727-4010-8985-34002e8f326b">
